### PR TITLE
Changes to support individually versioned protocols

### DIFF
--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -240,13 +240,13 @@ def packages(ctx, i):
         click.echo('\n{:^90}'.format("YOUR PACKAGES:\n"))
         click.echo('{:^30}'.format("PACKAGE NAME") + "|" +
                '{:^30}'.format("PACKAGE ID")
-               + "|" + '{:^30}'.format("LATEST PUBLISHED VERSION"))
+               + "|" + '{:^30}'.format("LATEST PUBLISHED RELEASE"))
         click.echo('{:-^90}'.format(''))
       elif category == "theirs" and list(packages.values()):
         click.echo('\n{:^90}'.format("OTHER PACKAGES IN YOUR ORG:\n"))
         click.echo('{:^30}'.format("PACKAGE NAME") + "|" +
                    '{:^30}'.format("PACKAGE ID") + "|" +
-                   '{:^30}'.format("LATEST PUBLISHED VERSION"))
+                   '{:^30}'.format("LATEST PUBLISHED RELEASE"))
         click.echo('{:-^90}'.format(''))
       for name, p in list(packages.items()):
         click.echo('{:<30}'.format(name) + "|" +
@@ -433,11 +433,11 @@ def resources(ctx, query):
 def init(path):
   '''Initialize a directory with a manifest.json file.'''
   manifest_data = OrderedDict(
-    version="1.0.0",
     format="python",
     license="MIT",
     protocols = [{
       "name": "SampleProtocol",
+      "version": "0.0.1",
       "display_name" :"Sample Protocol",
       "description" :"This is a protocol.",
       "command_string" :"python sample_protocol.py",


### PR DESCRIPTION
The web app will soon ship a change which individually versions protocols.  These are some small changes to accommodate that diff.  This does not need to be landed until the diff in the web app is live.  See the phab diff and task below.

D3907
T4539