### PR TITLE
A few small enhancements for the `launch` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 ---
+## v2.0.8
+Added
+- `launch` command now supports --save_input option to save the protocol input as a local file
+
+Fixed
+- `launch` command now properly supported either a project name or project id for the `project` option
+- typo AutoProtocol -> Autoprotocol
 
 ## v2.0.7
 Added

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='transcriptic',
     description='Transcriptic CLI & Python Client Library',
     url='https://github.com/transcriptic/transcriptic',
-    version='2.0.7',
+    version='2.0.8',
     packages=['transcriptic', 'transcriptic.analysis'],
     install_requires=[
         'Click>=5.1',

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -604,7 +604,7 @@ def launch(ctx, protocol, project, save_input):
     count += 1
 
   # Save the protocol input locally if the user specified the save_input option
-  if save_input is not None:
+  if save_input:
     try:
       with click.open_file(save_input, 'w') as f:
         f.write(json.dumps(quick_launch["inputs"], indent=2))


### PR DESCRIPTION
Added
- `launch` command now supports --save_input option to save the protocol input as a local file

Fixed
- `launch` command now properly supported either a project name or project id for the `project` option
- typo AutoProtocol -> Autoprotocol