### PR TITLE
Deserializing manifest into OrderedDict to preserve key ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 ---
+## v2.0.9
+Added
+- Updated manifest json parsing to deserialize into an OrderedDict, preserving key order, which enables quick launch inputs to be ordered
+
 ## v2.0.8
 Added
 - `launch` command now supports --save_input option to save the protocol input as a local file

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='transcriptic',
     description='Transcriptic CLI & Python Client Library',
     url='https://github.com/transcriptic/transcriptic',
-    version='2.0.8',
+    version='2.0.9',
     packages=['transcriptic', 'transcriptic.analysis'],
     install_requires=[
         'Click>=5.1',

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -711,7 +711,7 @@ def get_package_name(ctx, id):
 def load_manifest():
   try:
     with click.open_file('manifest.json', 'r') as f:
-      manifest = json.loads(f.read())
+      manifest = json.loads(f.read(), object_pairs_hook=OrderedDict)
   except IOError:
     click.echo("The current directory does not contain a manifest.json file.")
     sys.exit(1)


### PR DESCRIPTION
- This results in QuickLaunch configuration screens maintaining input ordering as defined in the manifest