### PR TITLE
Add api route for getting zipfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 Added
+- New API route for getting zipfiles: `api.get_zip`
 - Made -h option synonymous with --help
 
 ## v3.0.2

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -287,6 +287,14 @@ class Connection(object):
             '404': lambda resp: Exception("[404] No run found for ID " + id)
         })
 
+    def get_zip(self, data_id):
+        """Get zip file with given data_id. Returns Python Zipfile"""
+        import zipfile
+        from io import BytesIO
+        route = self.get_route('get_data_zip', data_id=data_id)
+        req = self.get(route, status_response={'200': lambda resp: resp}, stream=True)
+        return zipfile.ZipFile(BytesIO(req.content))
+
     def get_route(self, method, **kwargs):
         """Helper function to automatically match and supply required arguments"""
         route_method = getattr(routes, method)

--- a/transcriptic/routes.py
+++ b/transcriptic/routes.py
@@ -116,5 +116,9 @@ def view_raw_image(api_root, data_id):
     return "{api_root}/-/{data_id}.raw".format(**locals())
 
 
+def get_data_zip(api_root, data_id):
+    return "{api_root}/-/{data_id}.zip".format(**locals())
+
+
 def monitoring_data(api_root, org_id, project_id, run_id, instruction_id, data_type):
     return "{api_root}/{org_id}/{project_id}/runs/{run_id}/{instruction_id}/monitoring/{data_type}".format(**locals())


### PR DESCRIPTION
- Allows users to get a data zipfile by using `api.get_zip`
- This returns a Python [Zipfile](https://docs.python.org/2/library/zipfile.html) filetype, which can then be further processed according to the user's intent
