### PR TITLE
Add bash completion to TxPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 Added
+- Tab completion for CLI (enabled by sourcing `transcriptic_complete.sh`)
 - New API route for getting zipfiles: `api.get_zip`
 - Made -h option synonymous with --help
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ Password:
 Logged in as me@example.com (example-lab)
 ```
 
+To enable auto tab-completion for the Transcriptic CLI, enter `source transcriptic_complete.sh` into your terminal.
+To enable this for every single session automatically, add `. path/to/transcriptic_complete.sh` to your `.bashrc`/`.zshrc` file.
+
 ## Documentation
 
 See the [Transcriptic Developer Documentation](https://developers.transcriptic.com/docs/getting-started-with-the-cli) for detailed information about how to use this package, including learning about how to package protocols and build releases.
 
-View [developer specific documentation](http://transcriptic.readthedocs.io/en/latest/)
+View [Developer Specific Documentation](http://transcriptic.readthedocs.io/en/latest/)
 
 ## Contributing
 

--- a/transcriptic_complete.sh
+++ b/transcriptic_complete.sh
@@ -1,0 +1,8 @@
+_transcriptic_completion() {
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   _TRANSCRIPTIC_COMPLETE=complete $1 ) )
+    return 0
+}
+
+complete -F _transcriptic_completion -o default transcriptic;


### PR DESCRIPTION
Added bash completion to TxPy, which can be enabled by sourcing the `transcriptic_complete.sh`
Also added instructions into the readme for setting this up
