### PR TITLE
Enable downloading of large zip files for api.get_zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## `transcriptic` Changelog
 
 ## Unreleased
+Added
+- Ability for `api.get_zip` to handle larger zip-files by downloading to a local file
 
 ## v3.2.5
 Fixed


### PR DESCRIPTION
In the past, `api.get_zip` automatically downloaded zip files to memory and returned a Python ZipFile representation. However, when dealing with large zip files, it may not be desirable (or possible) to load the entire file into memory.

This PR fixes the issue by adding a `file_path` option to `get_zip` to enable downloading of big files to a specified local file_path.
