### PR TITLE
Adding in `select_org` to CLI and User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## `transcriptic` Changelog
 
 ## Unreleased
+Added
+- `transcriptic select_org` in CLI now allows you to switch organizations without re-authenticating
+- Added `User-agent` information to headers
+
 ## v3.3.1
 Fixed
 - Updated `transcriptic runs` route to reflect reality

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -36,3 +36,27 @@ class TestAnalyze:
 
         mockRoute(call, route, response_db["mock200"], max_calls=1)
         assert test_api.analyze_run(json_db['singleTransfer']) == json_db['singleTransfer_response']
+
+    def testGetOrganizations(self, test_api, json_db, response_db):
+        # Setup parameters for route mocking
+        route = test_api.get_route('get_organizations')
+        call = 'get'
+
+        mockRoute(call, route, response_db["mock404"], max_calls=1)
+        with pytest.raises(Exception):
+            test_api.organizations()
+
+        mockRoute(call, route, response_db["mock200"], max_calls=1)
+        assert test_api.organizations() == json_db['singleTransfer_response']
+
+    def testGetOrganization(self, test_api, json_db, response_db):
+        # Setup parameters for route mocking
+        route = test_api.get_route('get_organization', org_id="mock")
+        call = 'get'
+
+        mockRoute(call, route, response_db["mock404"], max_calls=1)
+        with pytest.raises(Exception):
+            test_api.get_organization(org_id="mock")
+
+        mockRoute(call, route, response_db["mock200"], max_calls=1)
+        assert (test_api.get_organization(org_id="mock")).json() == json_db['singleTransfer_response']

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -771,21 +771,21 @@ def select_org(ctx):
             click.echo("{}.  {} ({})".format(indx + 1, o['name'], o['subdomain']))
 
         def parse_valid_org(indx):
+            from click.exceptions import BadParameter
             try:
                 return org_list[int(indx) - 1]['subdomain']
             except:
-                click.echo("Please enter an integer between 1 and %s" %
-                           (len(org_list)))
-                sys.exit(1)
+                raise BadParameter("Please enter an integer between 1 and %s" %
+                                   (len(org_list)), ctx=ctx)
 
         organization = click.prompt(
-            'Which organization would you like to login as',
+            'Which organization would you like to log in as',
             default=1,
             prompt_suffix='? ', type=int,
             value_proc=lambda x: parse_valid_org(x)
         )
 
-    r = ctx.obj.api.get_organization()
+    r = ctx.obj.api.get_organization(org_id=organization)
     if r.status_code != 200:
         click.echo("Error accessing organization: %s" % r.text)
         sys.exit(1)
@@ -834,15 +834,15 @@ def login(ctx, api_root):
             click.echo("%s.  %s (%s)" % (indx + 1, o['name'], o['subdomain']))
 
         def parse_valid_org(indx):
+            from click.exceptions import BadParameter
             try:
                 return user['organizations'][int(indx) - 1]['subdomain']
             except:
-                click.echo("Please enter an integer between 1 and %s" %
-                           (len(user['organizations'])))
-                sys.exit(1)
+                raise BadParameter("Please enter an integer between 1 and %s" %
+                                   (len(user['organizations'])), ctx=ctx)
 
         organization = click.prompt(
-            'Which organization would you like to login as',
+            'Which organization would you like to log in as',
             default=1,
             prompt_suffix='? ', type=int,
             value_proc=lambda x: parse_valid_org(x)

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -7,6 +7,8 @@ from os.path import expanduser
 from . import routes
 from autoprotocol import Protocol
 import requests
+from .version import __version__
+import platform
 
 
 class Connection(object):
@@ -77,9 +79,9 @@ class Connection(object):
             "X-User-Email": email,
             "X-User-Token": token,
             "Content-Type": "application/json",
-            "Accept": "application/json"
+            "Accept": "application/json",
+            "User-agent": "txpy/{} {}".format(__version__, platform.platform())
         }
-
         # Preload known environment arguments
         self.env_args = dict(api_root=self.api_root, org_id=self.organization_id)
         transcriptic.api = self
@@ -125,6 +127,17 @@ class Connection(object):
                              '302': lambda resp: resp.headers['Location'],
                              'default': lambda resp: Exception("cannot preview protocol.")
                          })
+
+    def organizations(self):
+        """Get list of organizations"""
+        route = self.get_route('get_organizations')
+        return self.get(route)
+
+    def get_organization(self, org_id=None):
+        """Get particular organization"""
+        route = self.get_route('get_organization', org_id=org_id)
+        resp = self.get(route, status_response={'200': lambda resp: resp, 'default': lambda resp: resp})
+        return resp
 
     def projects(self):
         """Get list of projects in organization"""

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -80,7 +80,13 @@ class Connection(object):
             "X-User-Token": token,
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-agent": "txpy/{} {}".format(__version__, platform.platform())
+            "User-Agent": "txpy/{} ({}/{}; {}/{}; {}; {})".format(__version__,
+                                                                  platform.python_implementation(),
+                                                                  platform.python_version(),
+                                                                  platform.system(),
+                                                                  platform.release(),
+                                                                  platform.machine(),
+                                                                  platform.architecture()[0])
         }
         # Preload known environment arguments
         self.env_args = dict(api_root=self.api_root, org_id=self.organization_id)

--- a/transcriptic/routes.py
+++ b/transcriptic/routes.py
@@ -80,7 +80,11 @@ def login(api_root):
     return "{api_root}/users/sign_in".format(**locals())
 
 
-def get_organizations(api_root, org_id):
+def get_organizations(api_root):
+    return "{api_root}/organizations".format(**locals())
+
+
+def get_organization(api_root, org_id):
     return "{api_root}/{org_id}".format(**locals())
 
 


### PR DESCRIPTION
This PR adds in the `select_org` command to the Python CLI, as well as the User-Agent field to the headers portion of the request. 