### PR TITLE
Add upload_dataset functionality to api object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## `transcriptic` Changelog
 
 ## Unreleased
+Added
+- `upload_dataset` to api object and surrounding infrastructure
+
 ## v4.1.2
 Fixed
 - Quick bugfix to `run.data` route due to breaking web change

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
         'numpy>=1.10',
         'plotly==1.9.6',
         'pillow>=3.1.0',
-        'future>=0.15'
+        'future>=0.15',
+        'python-magic>=0.4.13'
     ],
     entry_points='''
         [console_scripts]

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -14,6 +14,7 @@ try:
     from io import StringIO
 except ImportError:
     from StringIO import StringIO
+import magic
 
 
 class Connection(object):
@@ -405,8 +406,8 @@ class Connection(object):
                                           "right permissions.".format(run_id))
         }, timeout=timeout)
 
-    def upload_dataset_from_file(self, file_path, title, run_id,
-                                 analysis_tool, analysis_tool_version):
+    def upload_dataset_from_filepath(self, file_path, title, run_id,
+                                     analysis_tool, analysis_tool_version):
         """
         Helper for uploading a file as a dataset to the specified run.
         
@@ -414,7 +415,7 @@ class Connection(object):
         
         .. code-block:: python
         
-            api.upload_dataset(
+            api.upload_dataset_from_filepath(
                 "my_file.txt", 
                 title="my cool dataset",
                 run_id="r123",
@@ -447,11 +448,7 @@ class Connection(object):
         except (AttributeError, FileNotFoundError) as e:
             raise ValueError("'file' has to be a valid filepath")
 
-        try:
-            import magic
-            content_type = magic.from_file(file_path, mime=True)
-        except ImportError:
-            content_type = None
+        content_type = magic.from_file(file_path, mime=True)
 
         self.upload_dataset(file_handle, name, title, run_id, analysis_tool,
                             analysis_tool_version, content_type)

--- a/transcriptic/routes.py
+++ b/transcriptic/routes.py
@@ -132,6 +132,14 @@ def datasets(api_root, org_id, project_id, run_id):
     return "{api_root}/{org_id}/{project_id}/runs/{run_id}/data".format(**locals())
 
 
+def upload_uri(api_root):
+    return "{api_root}/upload/make_upload_uri".format(**locals())
+
+
+def upload_datasets(api_root):
+    return "{api_root}/api/datasets".format(**locals())
+
+
 def preview_protocol(api_root):
     return "{api_root}/runs/preview".format(**locals())
 


### PR DESCRIPTION
This adds the `upload_dataset_from_filepath` and `upload_dataset` functions to the `api` object, which allows a user to attach an analysis dataset to a specified run.

Usage examples
```
            api.upload_dataset_from_filepath(
                "my_file.txt", 
                title="my cool dataset",
                run_id="r123",
                analysis_tool="cool script",
                analysis_tool_version="v1.0.0"
            )

            # Uploading a data_frame via file_handle
            from io import StringIO
            
            temp_buffer = StringIO()
            my_df.to_csv(temp_buffer)

            api.upload_dataset(
                temp_buffer,
                name="my_df",
                title="my cool dataset",
                run_id="r123",
                analysis_tool="cool script",
                analysis_tool_version="v1.0.0"
            )
```