### PR TITLE
Ensure that output of --save_input from `transcriptic launch` is consistent for --local and remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## `transcriptic` Changelog
 
 ## Unreleased
+Updated
+- `transcriptic launch --save_input` now outputs the same type of JSON
 
 ## v5.2.0
 Added

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -1083,7 +1083,7 @@ def launch(ctx, protocol, project, save_input, local, accept_quote, params, pm=N
         if save_input:
             try:
                 with click.open_file(save_input, 'w') as f:
-                    f.write(json.dumps(quick_launch["inputs"], indent=2))
+                    f.write(json.dumps(quick_launch["raw_inputs"], indent=2))
             except Exception as e:
                 print_stderr("\nUnable to save inputs: %s" % str(e))
 
@@ -1110,6 +1110,7 @@ def launch(ctx, protocol, project, save_input, local, accept_quote, params, pm=N
 
         # Check for generation errors
         generation_errs = launch_protocol["generation_errors"]
+
         if len(generation_errs) > 0:
             for errors in generation_errs:
                 click.echo("\n\n" + str(errors["message"]))
@@ -1155,7 +1156,29 @@ def launch(ctx, protocol, project, save_input, local, accept_quote, params, pm=N
         if not params:
             run_protocol(manifest, protocol_obj, quick_launch["inputs"])
         else:
-            run_protocol(manifest, protocol_obj, json.load(params))
+            """
+            In the case of a local `launch`, we need to generate `inputs` from
+            `raw_inputs`, since the `run_protocol` function takes in JSON which 
+            is `inputs`-formatted
+            """
+            try:
+                params = json.loads(params.read())
+            except ValueError:
+                print_stderr("Unable to load parameters given. "
+                             "File is probably incorrectly formatted.")
+                return
+            quick_launch = ctx.obj.api.create_quick_launch(
+                data=json.dumps({"manifest": protocol_obj}),
+                project_id=project
+            )
+            inputs = ctx.obj.api.resolve_quick_launch_inputs(
+                params,
+                project_id=project,
+                quick_Launch_id=quick_launch
+            )
+            run_protocol(
+                manifest, protocol_obj, inputs
+            )
 
 
 def _create_launch_request(params, bsl=1, test_mode=False):
@@ -1194,6 +1217,7 @@ def _get_quick_launch(ctx, protocol, project):
         data=json.dumps({"manifest": protocol}),
         project_id=project
     )
+
     quick_launch_mtime = quick_launch["updated_at"]
 
     format_str = "\nOpening %s"

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -413,6 +413,16 @@ class Connection(object):
                                launch_request_id=launch_request_id)
         return self.get(route)
 
+    def resolve_quick_launch_inputs(self, raw_inputs, project_id=None,
+                                    quick_launch_id=None):
+        """Resolves `raw_inputs` to `inputs` for quick_launch"""
+        route = self.get_route(
+            'resolve_quick_launch_inputs',
+            project_id=project_id,
+            launch_request_id=quick_launch_id
+        )
+        return self.post(route, data=raw_inputs)
+
     def get_protocols(self):
         """Get list of available protocols"""
         route = self.get_route('get_protocols')

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -419,9 +419,9 @@ class Connection(object):
         route = self.get_route(
             'resolve_quick_launch_inputs',
             project_id=project_id,
-            launch_request_id=quick_launch_id
+            quick_launch_id=quick_launch_id
         )
-        return self.post(route, data=raw_inputs)
+        return self.post(route, json=raw_inputs)
 
     def get_protocols(self):
         """Get list of available protocols"""

--- a/transcriptic/routes.py
+++ b/transcriptic/routes.py
@@ -84,6 +84,11 @@ def create_quick_launch(api_root, org_id, project_id):
     return "{api_root}/{org_id}/{project_id}/runs/quick_launch".format(**locals())
 
 
+def resolve_quick_launch_inputs(api_root, project_id, quick_launch_id):
+    return "{api_root}/{org_id}/{project_id}/runs/quick_launch/" \
+           "{quick_launch_id}/resolve_inputs".format(**locals())
+
+
 def aws_upload():
     return "https://transcriptic-uploads.s3.amazonaws.com"
 

--- a/transcriptic/routes.py
+++ b/transcriptic/routes.py
@@ -84,7 +84,7 @@ def create_quick_launch(api_root, org_id, project_id):
     return "{api_root}/{org_id}/{project_id}/runs/quick_launch".format(**locals())
 
 
-def resolve_quick_launch_inputs(api_root, project_id, quick_launch_id):
+def resolve_quick_launch_inputs(api_root, org_id, project_id, quick_launch_id):
     return "{api_root}/{org_id}/{project_id}/runs/quick_launch/" \
            "{quick_launch_id}/resolve_inputs".format(**locals())
 


### PR DESCRIPTION
This PR updates `transcriptic launch` so that one can use the inputs saved from a `--local` launch for launching a run with the remote protocol. 

To preserve the old behavior and also allow for using the saved inputs for a `--local` launch, there has been some additional plumbing added in the CLI and Connection object for converting `raw_inputs` to `inputs`. 