### PR TITLE
Add `--test` flag to `transcriptic launch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 Updated
 - `transcriptic launch --save_input` now outputs the same type of JSON
+Added
+- `test` flag to `transcriptic launch`, enabling the submission of test runs via the launch command
 
 ## v5.2.0
 Added


### PR DESCRIPTION
This PR adds a test flag to transcriptic launch, which allows the submission of test runs (using test-containers) via the launch command (similar to launching a test run via transcriptic submit). 

Example: `transcriptic launch Pipetting Pipetting_test.json --project p1advzzu23m4n --test`