### PR TITLE
Add a `generate_protocol` CLI command that inits an example protocol.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include transcriptic/templates *

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     version=__version__,
     packages=['transcriptic', 'transcriptic.jupyter', 'transcriptic.analysis'],
     setup_requires=['pytest-runner'],
+    include_package_data=True,
     tests_require=[
         'pytest>=2.9.0',
         'tox>=2.3.1',
@@ -25,7 +26,8 @@ setup(
         'Click>=5.1',
         'requests>=2.0',
         'future>=0.15',
-        'python-magic>=0.4.13'
+        'python-magic>=0.4.13',
+        'Jinja2==2.8',
     ],
     extras_require={
         'jupyter': [
@@ -60,5 +62,5 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5'
-    ]
+    ],
 )

--- a/transcriptic/templates/manifest.json.jinja
+++ b/transcriptic/templates/manifest.json.jinja
@@ -1,0 +1,64 @@
+{
+  "license": "MIT",
+  "format": "python",
+  "protocols": [
+    {
+      "name": "{{ name }}",
+      "display_name": "{{ name }} example protocol",
+      "categories": [
+        "Example Protocol"
+      ],
+      "description": "This is an example description for a protocol.",
+      "version": "0.0.1",
+      "command_string": "python -m {{ name }}",
+      "inputs": {
+        "source_aliquot": {
+          "type": "aliquot",
+          "label": "Source aliquot",
+          "description": "Source Aliquot to transfer volume from"
+        },
+        "volume": {
+          "type": "volume",
+          "label": "Transfer volume per well",
+          "default": "20:microliter",
+          "description": "Volume to transfer from source well to every well of the destination container."
+        },
+        "dest_ctype": {
+          "label": "Destination Container type",
+          "type": "choice",
+          "default": "96-pcr",
+          "options": [
+            { "value": "96-pcr" },
+            { "value": "96-flat" },
+            { "value": "96-deep" },
+            { "value": "384-pcr" },
+            { "value": "384-flat" },
+            { "value": "384-echo" }
+          ]
+        }
+      },
+      "preview": {
+        "refs": {
+          "fake_source_container": {
+            "label": "Fake Source Container",
+            "type": "micro-2.0",
+            "store": "cold_20",
+            "cover": null,
+            "aliquots": {
+              "0": {
+                "name": "Fake Source Aliquot",
+                "volume": "1800.0:microliter",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "parameters": {
+          "source_aliquot": "fake_source_container/0",
+          "volume": "20:microliter",
+          "dest_ctype": "96-pcr"
+        }
+      }
+    }
+  ]
+}

--- a/transcriptic/templates/protocol.py.jinja
+++ b/transcriptic/templates/protocol.py.jinja
@@ -1,0 +1,41 @@
+################################################################################################
+# This example protocol will create a new destination container and
+# transfer `volume` amount of `source_aliquot` into each well.
+#
+# Test locally with some like the following, though will need to supply a valid project id.
+# You must be in the same directory as the manifest and the protocol for the command to succeed.
+#
+#   transcriptic launch --local {{ name }} -p SOME_PROJECT_ID
+#
+# For more information about autoprotocol-python check out the documentation.
+#
+#   http://autoprotocol-python.readthedocs.io/en/latest/
+#
+# For more information about editing the manifest.json check out the documentation.
+#
+#   https://developers.transcriptic.com/v1.0/docs/input-types
+################################################################################################
+
+
+def {{ name }}(protocol, params):
+    # These arguments and their types are specified in the manifest.json
+    #   source_aliquot is of type Well
+    #   volume is of type string and will be in the format similar to '100:microliter'
+    #   dest_ctype is of type string and will be one of the options specified in the manifest.
+    source_well = params["source_aliquot"]
+    volume      = params["volume"]
+    dest_ctype  = params["dest_ctype"]
+
+    # Create a ref for a the destination container
+    dest_container = protocol.ref("destination_container",
+                                  cont_type=dest_ctype,
+                                  storage="ambient")
+
+    for dest_well in dest_container.wells_from(0, 12):
+        # add an instruction to the protocol
+        protocol.transfer(source_well, dest_well, volume)
+
+
+if __name__ == '__main__':
+    from autoprotocol.harness import run
+    run({{ name }}, "{{ name }}")

--- a/transcriptic/templates/requirements.txt.jinja
+++ b/transcriptic/templates/requirements.txt.jinja
@@ -1,0 +1,2 @@
+autoprotocol>=3.9.0,<4.0
+autoprotocol_utilities>=2.1.7,<3.0


### PR DESCRIPTION
Summary:
Creating a python protocol can be tough going.  One must understand
autoprotocol-py, the format of the manifest.json, and know which
dependencies are required.

The `generate_protocol` command should make it easier for both new and
old users to get up and running when writing protocols.

Test Plan:
Manually attempt to generate a protocol, and verify that it preview succeeds.

  `transcriptic generate_protocol foo`
  `transcriptic preview foo`

Reviewers: yangchoo, peter

Differential Revision: https://work.r23s.net/D9168