### PR TITLE
Expose Aliquot Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 ## `transcriptic` Changelog
+
+## Unreleased Changes:
+Added
+- Added `Connection.from_default_config()` method and tests
+- Added `Connection.modify_aliquot_properties()` for aliquot property managment
+
+Updated
+- Lint and cleanup
+- Starter work on testing `Connection` methods.
+
 ## v5.6.0
 Updated
 - run tox tests against python 3.5 instead of 3.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,20 @@
 # Contributing
 
 ## Structure
-The Transcriptic Python Library (TxPy) is separated into two main portions: the command line interface (CLI) and the
-Jupyter notebook interface.
+The Transcriptic Python Library (TxPy) is separated into two main portions: the command line interface (CLI) and the Jupyter notebook interface.
 
-Both the CLI and the notebook interface uses the base `Connection` object for making relevant application programming
- interface (API) calls to Transcriptic.
-The `Connection` object itself uses the `routes` module to figure out the relevant routes and passes that onto the `api`
-module for making these calls.
+Both the CLI and the notebook interface uses the base `Connection` object for making relevant application programming  interface (API) calls to Transcriptic.
+The `Connection` object itself uses the `routes` module to figure out the relevant routes and passes that onto the `api` module for making these calls.
 
-The base functionality of the CLI is handled by the `cli` module which is the front-facing interface for users. The
-`english` module provides autoprotocol parsing functionalities, and the `util` module provides additional generic helper functions.
+The base functionality of the CLI is handled by the `cli` module which is the front-facing interface for users. The `english` module provides autoprotocol parsing functionalities, and the `util` module provides additional generic helper functions.
 
-The base functionality of the notebook interface is exposed through the `objects` module. Additional analysis of these
- objects is provided through the `analysis` module. In general, html representations should be provided as much as possible.
+The base functionality of the notebook interface is exposed through the `objects` module. Additional analysis of these objects is provided through the `analysis` module. In general, html representations should be provided as much as possible.
 
-For analysis purposes, we prefer using Pandas DataFrames and NumPy arrays for representing and slicing data. For plotting,
-matplotlib and plotly is preferred.
+For analysis purposes, we prefer using Pandas DataFrames and NumPy arrays for representing and slicing data. For plotting, matplotlib and plotly is preferred.
 
 
 ## Version Compatibility
-We use the [future](https://pypi.python.org/pypi/future) module to maintain Python 2/3 compatibility. As a result, all
-code written should be Python 2.6/2.7 and Python 3.3+ compatible.
+We use the [future](https://pypi.python.org/pypi/future) module to maintain Python 2/3 compatibility. As a result, all code written should be Python 2.7 and Python 3.5+ compatible.
 
 
 ## Styling and Documentation

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'coverage==4.*',
         'future>=0.15',
         'jsonschema>=2.5',
+        'mock>=2.*',
         'pylint==1.*',
         'pytest==3.*',
         'tox==3.*'

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,0 +1,53 @@
+import json
+import os
+import unittest
+import tempfile
+
+import transcriptic.config
+
+class ConnectionInitTests(unittest.TestCase):
+    def test_inits_valid(self):
+        with tempfile.NamedTemporaryFile() as config_file:
+
+            with open(config_file.name, 'w') as f:
+                json.dump(
+                    {
+                        "email": "somebody@transcriptic.com",
+                        "token": "foobarinvalid",
+                        "organization_id": "transcriptic",
+                        "api_root": "http://foo:5555",
+                        "analytics": True,
+                        "user_id": "ufoo2",
+                        "feature_groups": [
+                            "can_submit_autoprotocol",
+                            "can_upload_packages"
+                        ]
+                    },
+                    f
+                )
+
+            transcriptic.config.Connection.from_file(config_file.name)
+
+    def test_inits_invalid(self):
+        with tempfile.NamedTemporaryFile() as config_file:    
+            with open(config_file.name, 'w') as f:
+                json.dump(
+                    {
+                        "email": "somebody@transcriptic.com",
+                        # "token": "foobarinvalid",  (missing token)
+                        "organization_id": "transcriptic",
+                        "api_root": "http://foo:5555",
+                        "analytics": True,
+                        "user_id": "ufoo2",
+                        "feature_groups": [
+                            "can_submit_autoprotocol",
+                            "can_upload_packages"
+                        ]
+                    },
+                    f
+                )
+
+            # TODO(meawoppl) - assertRaisesRegexp deprecated in py3
+            # Move it to assertRaisesRegex()
+            with self.assertRaisesRegexp(OSError, "token"):
+                transcriptic.config.Connection.from_file(config_file.name)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -79,7 +79,9 @@ class ConnectionInitTests(unittest.TestCase):
     def test_aliquot_modify(self):
         session, connection = self.get_mocked_connection()
 
-        connection.modify_aliquot_properties("23534245", {"prop1": "val1"})
+        aliquot_id = "23534245"
+        props = {"prop1": "val1"}
+        connection.modify_aliquot_properties(aliquot_id, props)
         session.put.assert_called_with(
             'https://fake.transcriptic.com/api/aliquots/23534245/modify_properties',
-            data='{"delete_properties": [], "set_properties": {"prop1": "val1"}}')
+            json={"id": aliquot_id, "data": {"delete": [], "set": props}})

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -51,3 +51,31 @@ class ConnectionInitTests(unittest.TestCase):
             # Move it to assertRaisesRegex()
             with self.assertRaisesRegexp(OSError, "token"):
                 transcriptic.config.Connection.from_file(config_file.name)
+
+    def test_aliquot_modify(self):
+        # NOTE(meawoppl) - This could be the start of a testing pattern
+        # for this module.
+        class FakeReturn:
+            status_code=200
+
+            def json(self):
+                return {}
+
+        faked_session = transcriptic.config.initialize_default_session()
+
+        calls = []
+        def mock_put(*args, **kwargs):
+            calls.append((args, kwargs))
+            return FakeReturn()
+
+        faked_session.put = mock_put
+
+        connection = transcriptic.config.Connection(
+            email="foo@transcriptic.com",
+            token="bar",
+            organization_id="txid",
+            api_root="https://fake.transcriptic.com",
+            session=faked_session)
+
+        connection.modify_aliquot_properties("23534245", {"prop1": "val1"})
+        self.assertTrue(len(calls) > 0)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,9 +1,9 @@
 import json
-import os
 import unittest
 import tempfile
 
 import transcriptic.config
+
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -13,7 +13,6 @@ except ImportError:
 class ConnectionInitTests(unittest.TestCase):
     def test_inits_valid(self):
         with tempfile.NamedTemporaryFile() as config_file:
-
             with open(config_file.name, 'w') as f:
                 json.dump(
                     {
@@ -73,7 +72,8 @@ class ConnectionInitTests(unittest.TestCase):
             token="bar",
             organization_id="txid",
             api_root="https://fake.transcriptic.com",
-            session=session)
+            session=session
+        )
         return session, connection
 
     def test_aliquot_modify(self):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = clean,py{27,35},stats,lint,docs
 
 [travis]
 python =
-    2.7.6: clean,py27,stats
+    2.7: clean,py27,stats
     3.5: clean,py35,stats,lint,docs
 
 [testenv:clean]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = clean,py{27,35},stats,lint,docs
 
 [travis]
 python =
-    2.7: clean,py27,stats
+    2.7.6: clean,py27,stats
     3.5: clean,py35,stats,lint,docs
 
 [testenv:clean]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
     coverage run --source {toxinidir}/transcriptic -a -m pytest
 deps =
     coverage==4.*
-    mock
+    mock==2.*
     pytest==3.*
     pylint==1.*
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
     coverage run --source {toxinidir}/transcriptic -a -m pytest
 deps =
     coverage==4.*
+    mock
     pytest==3.*
     pylint==1.*
 

--- a/transcriptic/__init__.py
+++ b/transcriptic/__init__.py
@@ -9,8 +9,8 @@ Transcriptic
 ============
 
 The Transcriptic library is separated into three components:
-1) Core. The core modules provide a barebones client for making calls to 
-the Transcriptic webapp to create and obtain data. This can be done via the 
+1) Core. The core modules provide a barebones client for making calls to
+the Transcriptic webapp to create and obtain data. This can be done via the
 `api` object or via the command-line using the CLI.
 2) Jupyter. This module provides a Jupyter-centric means for interacting with
 objects returned from the Transcriptic webapp such as Run, Project and Dataset.

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -927,9 +927,9 @@ def login(api, config, api_root=None, analytics=True):
                 '200': lambda resp: resp,
                 '401': lambda resp: resp,
                 'default': lambda resp: resp
-            },
-            custom_request=False
+            }
         )
+
     except requests.exceptions.RequestException:
         click.echo("Error logging into specified host: {}. Please check your "
                    "internet connection and host name".format(api_root))
@@ -945,15 +945,17 @@ def login(api, config, api_root=None, analytics=True):
     feature_groups = user.get('feature_groups')
     organization = org_prompt(user['organizations'])
 
-    r = api.get(routes.get_organization(api_root=api_root, org_id=organization), headers={
-        'X-User-Email': email,
-        'X-User-Token': token,
-        'Accept': 'application/json',
-    }, status_response={
-        '200': lambda resp: resp,
-        'default': lambda resp: resp
-    },
-        custom_request=True)
+    r = api.get(
+        routes.get_organization(api_root=api_root, org_id=organization),
+        headers={
+            'X-User-Email': email,
+            'X-User-Token': token,
+            'Accept': 'application/json'},
+        status_response={
+            '200': lambda resp: resp,
+            'default': lambda resp: resp}
+    )
+
     if r.status_code != 200:
         click.echo("Error accessing organization: %s" % r.text)
         sys.exit(1)

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -406,12 +406,13 @@ class Connection(object):
         route = self.get_route("modify_aliquot_properties", aliquot_id=aliquot_id)
         return self.put(
             route,
-            data=json.dumps({
+            json={
+                "id": aliquot_id,
                 "data": {
-                    "set_properties": set_properties,
-                    "delete_properties": delete_properties
+                    "set": set_properties,
+                    "delete": delete_properties
                 }
-            })
+            }
         )
 
     def packages(self):

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -107,11 +107,18 @@ class Connection(object):
         api.project_id = "p123"
 
     """
-    def __init__(self, email=None, token=None, organization_id=None,
-                 api_root="https://secure.transcriptic.com",
-                 cookie=None, verbose=False, analytics=True,
-                 user_id="default", feature_groups=[],
-                 session=None):
+    def __init__(
+            self,
+            email=None,
+            token=None,
+            organization_id=None,
+            api_root="https://secure.transcriptic.com",
+            cookie=None,
+            verbose=False,
+            analytics=True,
+            user_id="default",
+            feature_groups=[],
+            session=None):
         # Initialize environment args used for computing routes
         self.env_args = dict()
         self.api_root = api_root
@@ -398,7 +405,7 @@ class Connection(object):
         If specified delete_properties must be a list of string
         properties which will be deleted on the aliquot.
         """
-        route = self.get_route("modify_aliquot_properties")
+        route = self.get_route("modify_aliquot_properties", aliquot_id=aliquot_id)
         return self.put(
             route,
             data=json.dumps({

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -178,8 +178,8 @@ class Connection(object):
     @staticmethod
     def from_default_config():
         """
-        Load the default configuration file from the home directory of the current
-        user and return a Connection instance that is costructed from it.
+        Load the default configuration file from the home directory of the
+        current user and return a Connection instance that is costructed from it.
         """
         return Connection.from_file("~/.transcriptic")
 
@@ -777,12 +777,11 @@ class Connection(object):
         response: dict
             JSON-formatted response
         """
-        # NOTE(meawoppl) title argument is unused?
         try:
             file_path = os.path.expanduser(file_path)
             file_handle = open(file_path, 'rb')
             name = os.path.basename(file_handle.name)
-        except (AttributeError, FileNotFoundError) as e:
+        except (AttributeError, FileNotFoundError):
             raise ValueError("'file' has to be a valid filepath")
 
         try:
@@ -879,6 +878,8 @@ class Connection(object):
         key: str
             s3 key
         """
+        # NOTE(meawoppl) title argument is unused?
+
         # TODO:
         # Currently, we are passing `0` for file_size as it doesn't really
         # matter for non multipart uploads, though it would be better to

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -8,6 +8,7 @@ import platform
 import sys
 import time
 import warnings
+import zipfile
 
 from builtins import object, str
 import requests
@@ -751,7 +752,7 @@ class Connection(object):
         .. code-block:: python
 
             api.upload_dataset_from_filepath(
-                "my_file.txt", 
+                "my_file.txt",
                 title="my cool dataset",
                 run_id="r123",
                 analysis_tool="cool script",
@@ -776,6 +777,7 @@ class Connection(object):
         response: dict
             JSON-formatted response
         """
+        # NOTE(meawoppl) title argument is unused?
         try:
             file_path = os.path.expanduser(file_path)
             file_handle = open(file_path, 'rb')
@@ -951,7 +953,6 @@ class Connection(object):
             A Python ZipFile is returned unless `file_path` is specified
 
         """
-        import zipfile
         route = self.get_route('get_data_zip', data_id=data_id)
         req = self.get(
             route,

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -122,6 +122,7 @@ class Connection(object):
             session = initialize_default_session()
         self.session = session
 
+        # NB: These many setattr calls update self.session.headers
         # cookie authentication is mutually exclusive from token authentication
         if cookie:
             if email is not None or token is not None:

--- a/transcriptic/routes.py
+++ b/transcriptic/routes.py
@@ -154,7 +154,7 @@ def upload_datasets(api_root):
 
 
 def modify_aliquot_properties(api_root, aliquot_id):
-    return "{api_root}/api/aliquots/{aliquot_id}/modify_properties.json".format(**locals())
+    return "{api_root}/api/aliquots/{aliquot_id}/modify_properties".format(**locals())
 
 
 def preview_protocol(api_root):

--- a/transcriptic/routes.py
+++ b/transcriptic/routes.py
@@ -153,6 +153,10 @@ def upload_datasets(api_root):
     return "{api_root}/api/datasets".format(**locals())
 
 
+def modify_aliquot_properties(api_root, aliquot_id):
+    return "{api_root}/api/aliquots/{aliquot_id}/modify_properties.json".format(**locals())
+
+
 def preview_protocol(api_root):
     return "{api_root}/runs/preview".format(**locals())
 


### PR DESCRIPTION
- General work on `Connection()`:
  - Add testing support to Connection() and endpoints needed by script.
  - Added `Connection.from_default_config()` method and tests
  - Improved error handling of erroneous `Connection()` startup
  - Added shim to help test get/put in this context with injection of `requests.Session` object into parent class for easier testing
- Adding access to the aliquot labels:
  - Added api method interface.
  - Tested with web backend for aliquot changes.
- General lint and control flow cleanup