### PR TITLE
Update email references to point to strateos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Added
 Updated
 - Support only Python >=3.5, drop Python 2 support
 - Pin dependencies
+- Email references to point towards strateos
 
 ## v6.0.0
 Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-MAINTAINER Transcriptic <team@transcriptic.com>
+MAINTAINER Transcriptic <engineering@strateos.com>
 
 # Default userid=1000 as that is the first non-root userid on linux
 ARG uid=1000

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ View [Developer Specific Documentation](http://transcriptic.readthedocs.io/en/la
 
 ## Permissions
 
-Note that direct analysis and submission of Autoprotocol is currently restricted. Please contact sales@transcriptic.com if you would like to do so.
+Note that direct analysis and submission of Autoprotocol is currently restricted. Please contact sales@strateos.com if you would like to do so.
 
 ## Contributing
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -46,7 +46,7 @@ API calls are located in the `transcriptic.config` module for more advanced conn
 Permissions
 -----------
 
-Note that direct analysis and submission of Autoprotocol is currently restricted. Please contact sales@transcriptic.com if you would like to do so.
+Note that direct analysis and submission of Autoprotocol is currently restricted. Please contact sales@strateos.com if you would like to do so.
 
 
 Further Documentation


### PR DESCRIPTION
Udates the relevant email address to be in sync with the shift of domain names