### PR TITLE
Save preview params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## `transcriptic` Changelog
 
+## 
+Added 
+- "--test_inputs" flag added to the transcriptic cli "launch" command. Adding new flag will modify the quick launch inputs into usable preview parameters for protocol debugging.
+
 ## v7.0.0
 Added
 - zsh auto-completion support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 
 Added 
-- "--test_inputs" flag added to the transcriptic cli "launch" command. Adding new flag will modify the quick launch inputs into usable preview parameters for protocol debugging.
+- New CLI command `preview-params` will modify quick launch inputs into usable preview parameters for protocol debugging.
+
 
 ## v7.0.0
 Added

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -484,6 +484,46 @@ def launch_cmd(ctx, protocol, project, save_input, local, accept_quote, params, 
     api = ctx.obj.api
     commands.launch(api, protocol, project, save_input, local, accept_quote, params, pm=None, test=None, pkg=None)
 
+@cli.command('preview-params')
+@click.argument('protocol')
+@click.option(
+    '--project', '-p',
+    metavar='PROJECT_ID',
+    required=True,
+    help='Project id or name context for configuring the protocol. Use '
+         '`transcriptic projects` command to list existing projects.'
+)
+@click.option(
+    '--local',
+    is_flag=True,
+    required=False,
+    help='If include, the specified protocol will launch a from the local manifest file.'
+)
+@click.option(
+    '--filename', '-f',
+    metavar='FILE',
+    is_flag=True,
+    required=False,
+    help='If specified, will output generated preview params to file with '
+         'specified filename. The default will be "preview_parameters.json".'
+)
+@click.option(
+    '--merge', '-m',
+    is_flag=True,
+    required=False,
+    help='If specified, will merge the preview parameters generated into manifest used.'
+)
+@click.option(
+    '--pkg',
+    metavar='PACKAGE_ID',
+    required=False,
+    help='Package ID for discriminating between protocols with identical names'
+)
+@click.pass_context
+def generate_preview_parameters_cmd(ctx, protocol, project, local, filename, merge, pkg=None):
+    api = ctx.obj.api
+    commands.generate_preview_parameters(api, protocol, project, local, filename, merge, pkg=None)
+
 
 @cli.command('select_org')
 @click.argument(

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -705,7 +705,7 @@ def compile(protocol_name, args):
     call(["bash", "-c", command + " " + ' '.join(args)])
 
 
-def launch(api, protocol, project, save_input, local, accept_quote, params, test_inputs, pm=None, test=None, pkg=None):
+def launch(api, protocol, project, save_input, local, accept_quote, params, pm=None, test=None, pkg=None):
     """Configure and launch a protocol either using the local manifest file or remotely.
     If no parameters are specified, uses the webapp to select the inputs."""
     # Validate payment method
@@ -913,8 +913,8 @@ def generate_preview_parameters(api, protocol, project, local, filename, merge, 
                 f.write(json.dumps(pp.preview, indent=2))
                 f.close()
         except Exception as e:
-            print_stderr("\nUnable to save preview inputs due to not being able "
-                         "to process: %s %s" % type(e), str(e))
+            print_stderr("\nUnable to save preview inputs due to not being"
+                         " able to process: %s %s" % type(e), str(e))
     else:
         # Read manifest.json
         with click.open_file('manifest.json', 'r') as f:
@@ -948,8 +948,8 @@ def generate_preview_parameters(api, protocol, project, local, filename, merge, 
                 f.write(json.dumps(merged_manifest, indent=2))
                 f.close()
         except Exception as e:
-            print_stderr("\nUnable to save preview inputs due to not being able "
-                         "to process: %s %s" % type(e), str(e))
+            print_stderr("\nUnable to save preview inputs due to not being"
+                         " able to process: %s %s" % type(e), str(e))
 
 
 def select_org(api, config, organization=None):

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -14,10 +14,12 @@ from jinja2 import Environment, PackageLoader
 from os.path import isfile
 from transcriptic.english import AutoprotocolParser
 from transcriptic.config import Connection
-from transcriptic.util import iter_json, flatmap, ascii_encode, makedirs
+from transcriptic.util import iter_json, flatmap, ascii_encode, makedirs,\
+    PreviewParameters
 from transcriptic import routes
 
 import sys
+
 
 
 def submit(api, file, project, title=None, test=None, pm=None):
@@ -703,7 +705,7 @@ def compile(protocol_name, args):
     call(["bash", "-c", command + " " + ' '.join(args)])
 
 
-def launch(api, protocol, project, save_input, local, accept_quote, params, pm=None, test=None, pkg=None):
+def launch(api, protocol, project, save_input, local, accept_quote, params, test_inputs, pm=None, test=None, pkg=None):
     """Configure and launch a protocol either using the local manifest file or remotely.
     If no parameters are specified, uses the webapp to select the inputs."""
     # Validate payment method
@@ -864,6 +866,90 @@ def launch(api, protocol, project, save_input, local, accept_quote, params, pm=N
             run_protocol(
                 api, manifest, protocol_obj, inputs
             )
+
+def generate_preview_parameters(api, protocol, project, local, filename, merge, pkg=None):
+    """Generate preview parameters for a specified protocol from selected samples"""
+    # Load protocol from local file if not remote and load from listed protocols otherwise
+    if local:
+        manifest, protocol_obj = load_manifest_and_protocol(protocol)
+    else:
+        print_stderr("Searching for {}...".format(protocol))
+        protocol_list = api.get_protocols()
+
+        matched_protocols = [p for p in protocol_list if (
+            p['name'] == protocol and (pkg is None or p['package_id'] == pkg)
+        )]
+
+        if len(matched_protocols) == 0:
+            print_stderr(
+                "Protocol {} in {} was not found."
+                "".format(
+                    protocol,
+                    "package {}".format(pkg) if pkg else "unspecified package"
+                )
+            )
+            return
+        elif len(matched_protocols) > 1:
+            print_stderr("More than one match found. Using the first match.")
+        else:
+            print_stderr("Protocol found.")
+        protocol_obj = matched_protocols[0]
+    # Project is required for quick launch
+    if not project:
+        click.echo("Project field is required if parameters file is not specified.")
+        return
+    project = get_project_id(api, project)
+    if not project:
+        return
+    # Creates web browser and generates inputs for quick_launch
+    quick_launch = _get_quick_launch(api, protocol_obj, project)
+    pp = PreviewParameters(api, quick_launch["raw_inputs"])
+    # Determine where to place the generated preview parameters
+    if not merge:
+        if not filename:
+            filename = 'preview_parameters.json'
+        try:
+            with click.open_file(filename, 'w') as f:
+                f.write(json.dumps(pp.preview, indent=2))
+                f.close()
+        except Exception as e:
+            print_stderr("\nUnable to save preview inputs due to not being able "
+                         "to process: %s %s" % type(e), str(e))
+    else:
+        # Read manifest.json
+        with click.open_file('manifest.json', 'r') as f:
+            manifest = json.loads(f.read())
+        # Get selected protocol
+        selected_protocol = next(p for p in manifest['protocols'] if p['name'] == protocol)
+        # Get the index of the protocol in the protocols list
+        protocol_idx = manifest['protocols'].index(selected_protocol)
+        # Merge generated preview parameters into the selected protocol
+        selected_protocol['preview'] = pp.preview['preview']
+        # Ensure that the merged protocol object has the same key order
+        updated_protocol = OrderedDict()
+        updated_protocol['name'] = selected_protocol['name']
+        updated_protocol['display_name'] = selected_protocol['display_name']
+        updated_protocol['categories'] = selected_protocol['categories']
+        updated_protocol['description'] = selected_protocol['description']
+        updated_protocol['version'] = selected_protocol['version']
+        updated_protocol['command_string'] = selected_protocol['command_string']
+        updated_protocol['inputs'] = selected_protocol['inputs']
+        updated_protocol['preview'] = selected_protocol['preview']
+        # Place modified protocol in the appropriate index
+        manifest['protocols'][protocol_idx] = updated_protocol
+        # Ensure that manifest has correct order
+        merged_manifest = OrderedDict()
+        merged_manifest['format'] = "python"
+        merged_manifest['license'] = "MIT"
+        merged_manifest['protocols'] = manifest['protocols']
+        # Write new manifest to current working directory
+        try:
+            with click.open_file('manifest.json', 'w') as f:
+                f.write(json.dumps(merged_manifest, indent=2))
+                f.close()
+        except Exception as e:
+            print_stderr("\nUnable to save preview inputs due to not being able "
+                         "to process: %s %s" % type(e), str(e))
 
 
 def select_org(api, config, organization=None):

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -914,7 +914,7 @@ def generate_preview_parameters(api, protocol, project, local, filename, merge, 
                 f.close()
         except Exception as e:
             print_stderr("\nUnable to save preview inputs due to not being"
-                         " able to process: %s %s" % type(e), str(e))
+                         " able to process: {} {}".format(type(e), str(e)))
     else:
         # Read manifest.json
         with click.open_file('manifest.json', 'r') as f:
@@ -949,7 +949,7 @@ def generate_preview_parameters(api, protocol, project, local, filename, merge, 
                 f.close()
         except Exception as e:
             print_stderr("\nUnable to save preview inputs due to not being"
-                         " able to process: %s %s" % type(e), str(e))
+                         " able to process: {} {}".format(type(e), str(e)))
 
 
 def select_org(api, config, organization=None):

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -139,8 +139,7 @@ class Connection(object):
             self.token = token
 
         # Initialize feature groups
-        feature_groups = set(['can_submit_autoprotocol', 'can_upload_packages'])
-        self.feature_groups = list(feature_groups.intersection(feature_groups))
+        self.feature_groups = feature_groups
 
         # Initialize CLI parameters
         self.verbose = verbose
@@ -251,6 +250,13 @@ class Connection(object):
                           "exclusive. Clearing email and token from headers")
             self.update_headers(**{'X-User-Email': None, 'X-User-Token': None})
         self.update_headers(**{'Cookie': value})
+
+    def get_container(self, container_id):
+        route = self.get_route('get_container',
+                               org_id=self.organization_id,
+                               container_id=container_id
+                               )
+        return self.get(route)
 
     def save(self, path):
         """Saves current connection into specified file, used for CLI"""

--- a/transcriptic/routes.py
+++ b/transcriptic/routes.py
@@ -3,6 +3,9 @@ Big dumb file of routes, please do not add any logic into this file
 Note: {api_root} and {org_id} are automatically supplied in the Connection.get_route and do not need to be specified
 """
 
+def get_container(api_root, org_id, container_id):
+    return "{api_root}/{org_id}/samples/{container_id}".format(**locals())
+
 
 def create_project(api_root, org_id):
     return "{api_root}/{org_id}".format(**locals())

--- a/transcriptic/util.py
+++ b/transcriptic/util.py
@@ -3,6 +3,7 @@ import itertools
 import re
 import sys
 
+from collections import defaultdict
 
 def natural_sort(l):
     convert = lambda text: int(text) if text.isdigit() else text.lower()
@@ -146,3 +147,164 @@ def makedirs(name, mode=None, exist_ok=False):
     from os import makedirs
     mode = mode if mode is not None else 0o777
     makedirs(name, mode, exist_ok)
+
+class PreviewParameters:
+    """
+    A PreviewParameters object modifies web browser quick launch parameters and
+    modifies them for application protocol testing and debugging.
+
+    Attributes
+    ------
+    api : object
+        the Connection object to provide session for using api endpoints
+
+    quick_launch_params: dict
+        web browser generated inputs for quick launch
+
+    selected_samples: defaultdict
+        all aliquots selected through the web quick launch manifest
+
+    modified_params: dict
+        the modified quick launch launch parameters, converts quick launch
+        aliquot objects into strings for debugging
+
+    refs: dict
+        all unique refs seen in the quick launch parameters
+
+    preview: dict
+        the combination of refs and modified_params for scientific
+        application debugging
+    """
+    def __init__(self, api, quick_launch_params):
+        """
+        Initialize TestParameter by providing a web generated params dict.
+
+        Parameters
+        ----------
+        quick_launch_params: dict
+            web browser generated inputs for quick launch
+        """
+        self.api = api
+        self.container_cache = {}
+        self.selected_samples = {}
+        self.quick_launch_params = quick_launch_params
+        self.preview = self.build_preview()
+
+    def build_preview(self):
+        """Builds preview parameters"""
+        self.modified_params = self.modify_preview_parameters()
+        self.refs = self.generate_refs()
+        preview = defaultdict(lambda: defaultdict(dict))
+        preview['preview']["parameters"].update(self.modified_params)
+        preview['preview'].update(self.refs)
+        return preview
+
+    def modify_preview_parameters(self):
+        """
+        This method will traverse the quick launch 'raw_inputs' and modify
+        container ids and aliquot dicts into a preview parameter container
+        string for autoprotocol generation debugging.
+        """
+        return self.traverse(
+            obj=self.quick_launch_params, callback=self.create_preview_string
+        )
+
+    def generate_refs(self):
+        """
+        This method takes the aggregated containers and aliquots to produce
+        the refs aliquot values
+        """
+        ref_dict = defaultdict(lambda: defaultdict(dict))
+        for cid, index_arr in self.selected_samples.items():
+            container = self.container_cache.get(cid)
+            cont_name = PreviewParameters.format_container_name(container)
+            ref_dict['refs'][cont_name] = {
+                'label': cont_name,
+                'type': container.get('container_type').get('id'),
+                'store': container.get('storage_condition'),
+                'cover': container.get('cover', None),
+                'properties': container.get('properties')
+            }
+            if None not in index_arr:
+                ref_dict['refs'][cont_name]['aliquots'] = self.\
+                    get_selected_aliquots(container, index_arr)
+        return ref_dict
+
+    def traverse(self, obj, callback=None):
+        """
+        Will traverse quick launch object and send value to a callback
+        action method.
+        """
+        if isinstance(obj, dict):
+            # If object has 'containerId' and 'wellIndex', then it is an aliquot
+            if 'containerId' and 'wellIndex' in obj.keys():
+                return self.create_string_from_aliquot(value=obj)
+            else:
+                value = {k: self.traverse(v, callback) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self.traverse(elem, callback) for elem in obj]
+        else:
+            value = obj
+
+        if callback is None:
+            return value
+        else:
+            return callback(value)
+
+    def add_to_cache(self, container_id):
+        """Adds requested container to cache for later use"""
+        if container_id in self.container_cache:
+            container = self.container_cache[container_id]
+        else:
+            container = self.api.get_container(container_id)
+            self.container_cache[container_id] = container
+        return container
+
+    def create_string_from_aliquot(self, value):
+        """Creates preview aliquot representation"""
+        well_idx = value.get("wellIndex")
+        container_id = value.get("containerId")
+        container = self.add_to_cache(container_id)
+        cont_name = PreviewParameters.format_container_name(container)
+        self.add_to_selected(container_id, well_idx)
+        return '{}/{}'.format(cont_name, well_idx)
+
+    def create_preview_string(self, value):
+        """Creates preview parameters string representation"""
+        if isinstance(value, str):
+            if value[:2] == 'ct':
+                container_id = value
+                container = self.add_to_cache(container_id)
+                cont_name = PreviewParameters.format_container_name(container)
+                self.add_to_selected(container_id)
+                return cont_name
+            else:
+                return value
+        else:
+            return value
+
+    def add_to_selected(self, container_id, well_idx=None):
+        """Saves which containers were selected."""
+        if container_id in self.selected_samples:
+            self.selected_samples[container_id].append(well_idx)
+        else:
+            self.selected_samples[container_id] = [well_idx]
+
+    def get_selected_aliquots(self, container, index_arr):
+        """Grabs the properties from the selected aliquots"""
+        ref_aliquots = dict()
+        container_aliquots = {
+            ali.get('well_idx'): ali for ali in container.get('aliquots')
+        }
+        for i in index_arr:
+            ali = container_aliquots[i]
+            ref_aliquots[i] = {
+                'name': ali.get('name'),
+                'volume': '{}:microliter'.format(ali.get('volume_ul')),
+                'properties': ali.get('properties')
+            }
+        return ref_aliquots
+
+    @classmethod
+    def format_container_name(cls, container):
+        return container.get('label').replace(' ', '_')


### PR DESCRIPTION
The diff this pull request stems from:
- https://work.r23s.net/D13370 - `Creating launch command --debug_inputs flag to save inputs for protocol debugging` . Develops a feature to save manifest `"preview"` parameters from real containers using the `transcriptic launch` command with the `--test_inputs` flag.

However, since Travis was failing to build due to too many arguments in the `launch` command. I decided to pull this out into its own command, `preview-params`. The new feature will generate quick launch parameters from the remote or `--local` protocol. It will then either write a new `preview_parameter.json` or other filename if specified. Furthermore, the `--merge` flag will merge the newly generated preview parameters into the protocol manifest that was specified.

Other things in this pull request to note:
- Created new `get_container` route and configuration